### PR TITLE
Fix main nav CSS to display Nav as overlay #12

### DIFF
--- a/styles/layout.css
+++ b/styles/layout.css
@@ -1,6 +1,10 @@
+/* Navbar is always 50px so that's why I chose this number
+but remember that header has margin-top: 40px from bootstrap,
+so that's why it's not sticked to the navigation bar*/
 body {
   margin: 0 auto;
   text-align: center;
+  padding-top: 50px;
 }
 li {
   display: inline;


### PR DESCRIPTION
Hello friend,

I saw your issue with the navigation bar as I was browsing github.
The only way as far as I am concerned to fix this `bug` is to add padding-top to `body`.

You can have a look at this discussion on Stack Overflow:
http://stackoverflow.com/questions/11124777/twitter-bootstrap-navbar-fixed-top-overlapping-site

Please accept my pull request and take care :)
(P.S. more information about accepting pull requests --> https://help.github.com/articles/merging-a-pull-request/)